### PR TITLE
Rebalance tree, handle underflow and keep track of deleted PageIds

### DIFF
--- a/KlindaBase/Paging/PageFreeList.cs
+++ b/KlindaBase/Paging/PageFreeList.cs
@@ -1,0 +1,29 @@
+﻿namespace KlindaBase.Paging;
+
+public class PageFreeList
+{
+    public const int PageId = 1; // Rett etter MetadataPage (0)
+
+    public List<int> FreePageIds { get; set; } = new();
+
+    public byte[] Serialize()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+        writer.Write(FreePageIds.Count);
+        foreach (var id in FreePageIds)
+            writer.Write(id);
+        return ms.ToArray();
+    }
+
+    public static PageFreeList Deserialize(byte[] data)
+    {
+        using var ms = new MemoryStream(data);
+        using var reader = new BinaryReader(ms);
+        int count = reader.ReadInt32();
+        var list = new List<int>();
+        for (int i = 0; i < count; i++)
+            list.Add(reader.ReadInt32());
+        return new PageFreeList { FreePageIds = list };
+    }
+}

--- a/KlindaBase/Paging/PagedCore/PagedBPlusTree.cs
+++ b/KlindaBase/Paging/PagedCore/PagedBPlusTree.cs
@@ -110,7 +110,8 @@ public class PagedBPlusTree
         // Remove the key and its associated value from the leaf node
         leaf.Keys.RemoveAt(index);
         leaf.Values.RemoveAt(index);
-
+        _wal.LogDelete(node.PageId);
+        _pageManager.FreePage(node.PageId);
         if (leaf.Keys.Count < Math.Ceiling(_degree / 2.0))
         {
             HandleLeafUnderflow(leaf);


### PR DESCRIPTION
Two implementations for rebalancing tree and handle underflow upon deletions of leafs in the tree aswell as a freelist implementation to take care of deleted pageIds and being able to reuse them